### PR TITLE
Dockerfiles: Remove Redundant mkdir Command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.9.6 as build
-RUN mkdir -p /go/src/github.com/alexellis/hash-browns/
+
 WORKDIR /go/src/github.com/alexellis/hash-browns/
 
 RUN go get -d -v github.com/gorilla/mux && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,5 @@
 FROM alexellis2/go-armhf:1.7.4
 
-RUN mkdir -p /go/src/github.com/alexellis/hash-browns/
 WORKDIR /go/src/github.com/alexellis/hash-browns/
 
 RUN go get -d -v github.com/gorilla/mux && \


### PR DESCRIPTION
When using `WORKDIR` the directory will be created if it does not exist. https://docs.docker.com/engine/reference/builder/#workdir

So the `mkdir` commands are not needed.