### PR TITLE
Go cleanup

### DIFF
--- a/server.go
+++ b/server.go
@@ -3,12 +3,11 @@ package main
 import (
 	"crypto/sha256"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
-
-	"io/ioutil"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
 			histogram.WithLabelValues(fmt.Sprintf("%d", code)).Observe(duration.Seconds())
 		}()
 
-		code = http.StatusBadRequest
+		code = http.StatusMethodNotAllowed
 		if r.Method != http.MethodPost {
 			w.WriteHeader(code)
 

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -21,8 +22,8 @@ func computeSum(body []byte) []byte {
 	h := sha256.New()
 
 	h.Write(body)
-	hashed := h.Sum(nil)
-	return hashed
+	hashed := hex.EncodeToString(h.Sum(nil))
+	return []byte(hashed)
 }
 
 func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
@@ -50,8 +51,7 @@ func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
 		fmt.Printf("\"%s\"\n", string(body))
 
 		hashed := computeSum(body)
-		val := fmt.Sprintf("%x\n", hashed)
-		w.Write([]byte(val))
+		w.Write(hashed)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		defer r.Body.Close()
-		code := 500
+		code := http.StatusInternalServerError
 
 		defer func() { // Make sure we record a status.
 			duration := time.Since(start)
@@ -37,7 +37,7 @@ func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
 		}()
 
 		code = http.StatusBadRequest
-		if r.Method == "POST" {
+		if r.Method == http.MethodPost {
 			code = http.StatusOK
 			w.WriteHeader(code)
 			body, _ := ioutil.ReadAll(r.Body)

--- a/server.go
+++ b/server.go
@@ -37,20 +37,21 @@ func hashHandler(histogram *prometheus.HistogramVec) http.HandlerFunc {
 		}()
 
 		code = http.StatusBadRequest
-		if r.Method == http.MethodPost {
-			code = http.StatusOK
+		if r.Method != http.MethodPost {
 			w.WriteHeader(code)
-			body, _ := ioutil.ReadAll(r.Body)
 
-			fmt.Printf("\"%s\"\n", string(body))
-
-			hashed := computeSum(body)
-			val := fmt.Sprintf("%x\n", hashed)
-			w.Write([]byte(val))
-
-		} else {
-			w.WriteHeader(code)
+			return
 		}
+
+		code = http.StatusOK
+		w.WriteHeader(code)
+		body, _ := ioutil.ReadAll(r.Body)
+
+		fmt.Printf("\"%s\"\n", string(body))
+
+		hashed := computeSum(body)
+		val := fmt.Sprintf("%x\n", hashed)
+		w.Write([]byte(val))
 	}
 }
 


### PR DESCRIPTION
Use `if error return` style which is common in go and tidies up the code a little.
Use http package status codes instead of static "500".
Offload hex encoding to `computeSum` function.
Alphabetize import statements.