### PR TITLE
Docker Compose: Build And Use Local Image Instead Of Upstream

### DIFF
--- a/docker-compose.armhf.yml
+++ b/docker-compose.armhf.yml
@@ -11,7 +11,9 @@ services:
             constraints: [node.role == manager]
 
   hashbrowns:
-    image: alexellis2/hash-browns-armhf
+    build:
+      context: .
+      dockerfile: Dockerfile.armhf
     ports:
       - 8080:8080
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
 
   hashbrowns:
-    image: alexellis2/hash-browns:0.2
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - 8080:8080


### PR DESCRIPTION
This allows the user to changes *server.go* and build their own images while using docker-compose.